### PR TITLE
Fixed Brand Bar Overflow

### DIFF
--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -54,13 +54,13 @@
   }
 
   .layout__brandBar {
-    min-height: 100vh;
+    display: block;
     background-attachment: fixed;
   }
 
   .layout__brandBarInner {
-    position: fixed;
-    width: unset;
+    position: sticky;
+    top:4rem;
   }
 
   .layout__brandBarMoth {

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -60,7 +60,7 @@
 
   .layout__brandBarInner {
     position: sticky;
-    top:4rem;
+    top: 4rem;
   }
 
   .layout__brandBarMoth {


### PR DESCRIPTION
Used position:sticky instead of position:fixed to avoid the Logo overflowing outside of Brand Bar when making screensize smaller